### PR TITLE
Fixed incorrect 'four' in 4-multiple-linear-regression.md

### DIFF
--- a/learn-pr/azure/understand-regression-machine-learning/includes/4-multiple-linear-regression.md
+++ b/learn-pr/azure/understand-regression-machine-learning/includes/4-multiple-linear-regression.md
@@ -29,7 +29,7 @@ The reality is somewhere in between. Our model could predict temperature to some
 
 R<sup>2</sup> is only half the story.
 
-R<sup>2</sup> values are widely accepted, but aren't a perfect measure we can use in isolation. They suffer four limitations:
+R<sup>2</sup> values are widely accepted, but aren't a perfect measure we can use in isolation. They suffer from the following limitations:
 
 * Because of how R<sup>2</sup> is calculated, the more samples we have, the higher the R<sup>2</sup>. This can lead us to thinking that one model is better than another (identical) model, simply because R<sup>2</sup> values were calculated using different amounts of data.
 * R<sup>2</sup> values don't tell us how well a model will work with new, previously unseen data. Statisticians overcome this by calculating a supplementary measure, called a *p-value*, which we won't cover here. In machine learning, we often explicitly test our model on another dataset instead.


### PR DESCRIPTION
The text says "They suffer four limitations:" but 3 limitations are listed. 

Changed to "They suffer from the following limitations".


Before requesting or performing a merge in upstream:

- [x] Verify that your pull request is following our PR quality criteria (items that apply to All and Learn):
       https://review.learn.microsoft.com/help/contribute/contribute-how-to-write-pull-request-quality-criteria?branch=main
- [x] Verify your PR has a useful title that reflects what it is for.
