### PR TITLE
Fix duplicate word 'the the' in deployment stacks unit

### DIFF
--- a/learn-pr/azure/introduction-to-deployment-stacks/includes/3-why-deployment-stacks.md
+++ b/learn-pr/azure/introduction-to-deployment-stacks/includes/3-why-deployment-stacks.md
@@ -38,7 +38,7 @@ Deployment stacks allow you to delete the stack and all of its resources through
 
 Another advantage of deleting resources managed by a stack is the potential for cost savings. Deleting an application and its resources not managed by a deployment stack is many times a manual effort that is prone to error. It's possible to accidentally forget to delete certain resources, which continue to incur cost. Deployment stacks solve for this problem acting as a cost management tool, especially when dealing with ephemeral environments.
 
-When deleting a deployment stack, you can use the `actionOnUnmanage` property to determine how Azure handles the resources, resource groups, and management groups contained in the stack. Azure can delete the resources, resource groups, and management groups, or it can *detach* them, which means the the resources aren't deleted but are no longer managed by the stack.
+When deleting a deployment stack, you can use the `actionOnUnmanage` property to determine how Azure handles the resources, resource groups, and management groups contained in the stack. Azure can delete the resources, resource groups, and management groups, or it can *detach* them, which means the resources aren't deleted but are no longer managed by the stack.
 
 ### Standardized process and templates
 


### PR DESCRIPTION
## Summary
Fixes a minor typo: removes a duplicated word ("the the" → "the") in the *Introduction to deployment stacks* module.

## File changed
- `learn-pr/azure/introduction-to-deployment-stacks/includes/3-why-deployment-stacks.md`

## Diff
```diff
- ...which means the the resources aren't deleted but are no longer managed by the stack.
+ ...which means the resources aren't deleted but are no longer managed by the stack.