### PR TITLE
Fix typo in execution context unit

### DIFF
--- a/learn-pr/github/agent-tooling-mcp-execution-environments/includes/4-execution-context-boundaries.md
+++ b/learn-pr/github/agent-tooling-mcp-execution-environments/includes/4-execution-context-boundaries.md
@@ -85,7 +85,7 @@ Agents don't work directly on the main branch.
 
 Instead, they:
 
-- Create a new branch from the branch ypu selected
+- Create a new branch from the branch you selected
 - Make changes within that branch
 - Open a pull request targeting a base branch
 


### PR DESCRIPTION
Fixes a typo in the branch-based isolation section of the execution context unit.

Changed `ypu` to `you` in the phrase "branch you selected."