### PR TITLE
Fix broken mlflow.set_tracking_uri() sample in model-tracking unit

### DIFF
--- a/learn-pr/wwl-data-ai/experiment-azure-machine-learning/includes/5-model-tracking.md
+++ b/learn-pr/wwl-data-ai/experiment-azure-machine-learning/includes/5-model-tracking.md
@@ -45,7 +45,7 @@ When you prefer working in notebooks on a local device, you can also make use of
 6. Use the following code in your local notebook to configure MLflow to point to the Azure Machine Learning workspace, and set it to the workspace tracking URI.
 
     ```python
-    mlflow.set_tracking_uri = "MLFLOW-TRACKING-URI"
+    mlflow.set_tracking_uri("MLFLOW-TRACKING-URI")
     ```
 
 > [!Tip]


### PR DESCRIPTION
The current sample shows: mlflow.set_tracking_uri = "MLFLOW-TRACKING-URI"  mlflow.set_tracking_uri is a function, not an attribute meant to be assigned to. This line doesn't call the function, it rebinds the name mlflow.set_tracking_uri to a plain string, silently discarding the function object.