### PR TITLE
GA rename: Threat Hunting Assistant

### DIFF
--- a/learn-pr/wwl-sci/describe-threat-protection-with-microsoft-365-defender/includes/7a-describe-copilot-in-defender-xdr.md
+++ b/learn-pr/wwl-sci/describe-threat-protection-with-microsoft-365-defender/includes/7a-describe-copilot-in-defender-xdr.md
@@ -164,9 +164,9 @@ The Phishing Triage Agent requires Microsoft Defender for Office 365 Plan 2 and 
 
 The **Threat Intelligence Briefing Agent** provides security operations teams with regular, customized threat intelligence briefings. The agent autonomously gathers and synthesizes relevant threat intelligence data from various sources in Microsoft Defender Threat Intelligence and delivers concise, actionable insights to help analysts stay informed about emerging threats. Rather than requiring analysts to manually review threat reports across multiple consoles, the agent surfaces the threat intelligence most relevant to your organization on an ongoing basis.
 
-### Threat Hunting Agent
+### Threat Hunting Assistant
 
-The **Threat Hunting Agent** is an AI-powered agent available in advanced hunting that enables analysts to investigate threats using natural language from start to finish. Rather than requiring deep Kusto Query Language (KQL) expertise, the agent transforms natural-language questions into KQL queries, interprets the results, surfaces contextual insights, and guides analysts through complete hunting sessions. The agent maintains context throughout a session, enabling follow-up questions that build on previous ones, and provides smart suggestions to help drive the investigation forward. These capabilities empower analysts of all levels to hunt threats faster and with greater confidence.
+The **Threat Hunting Assistant** is an AI-powered agent available in advanced hunting that enables analysts to investigate threats using natural language from start to finish. Rather than requiring deep Kusto Query Language (KQL) expertise, the agent transforms natural-language questions into KQL queries, interprets the results, surfaces contextual insights, and guides analysts through complete hunting sessions. The agent maintains context throughout a session, enabling follow-up questions that build on previous ones, and provides smart suggestions to help drive the investigation forward. These capabilities empower analysts of all levels to hunt threats faster and with greater confidence.
 
 ### Dynamic Threat Detection Agent
 

--- a/learn-pr/wwl-sci/design-solutions-security-operations/includes/7-design-security-workflows.md
+++ b/learn-pr/wwl-sci/design-solutions-security-operations/includes/7-design-security-workflows.md
@@ -89,7 +89,7 @@ Microsoft Security Copilot integrates across security workflows to accelerate an
 |----------------|------------------------------|
 | **Incident triage** | Summarize incidents in natural language, identify attack scope, provide guided response actions with recommended next steps |
 | **Investigation** | Generate investigation queries, analyze scripts and files for malicious behavior, explain complex attack chains, correlate related alerts |
-| **Threat hunting** | Use the Threat Hunting Agent for conversational hunting and multistep investigations, or the query assistant to create KQL queries from natural language descriptions |
+| **Threat hunting** | Use the Threat Hunting Assistant for conversational hunting and multistep investigations, or the query assistant to create KQL queries from natural language descriptions |
 | **Response** | Provide step-by-step remediation guidance, generate response playbook recommendations |
 | **Reporting** | Create executive summaries, generate post-incident reports for stakeholders |
 

--- a/learn-pr/wwl-sci/manage-plugins-agents-security-copilot/media/agent-workspace-context.svg
+++ b/learn-pr/wwl-sci/manage-plugins-agents-security-copilot/media/agent-workspace-context.svg
@@ -14,9 +14,9 @@
   <rect x="14"  y="12" width="316" height="18" fill="white"/>
   <text x="17"  y="26" font-size="15" font-weight="bold" fill="#000000">SOC Workspace | Dedicated SOC capacity</text>
 
-  <!-- Agent box 1 – Threat Hunting Agent -->
+  <!-- Agent box 1 – Threat Hunting Assistant -->
   <rect x="20"  y="48" width="210" height="112" rx="4" ry="4" fill="#2869C9"/>
-  <text x="30"  y="85"  font-size="15" font-weight="bold" fill="#FFFFFF">Threat Hunting Agent</text>
+  <text x="30"  y="85"  font-size="15" font-weight="bold" fill="#FFFFFF">Threat Hunting Assistant</text>
   <text x="30"  y="107" font-size="15" fill="#FFFFFF">Plug-ins: Defender</text>
   <text x="30"  y="129" font-size="15" fill="#FFFFFF">XDR, Sentinel</text>
 

--- a/learn-pr/wwl-sci/security-copilot-describe-agents/6-module-assessment.yml
+++ b/learn-pr/wwl-sci/security-copilot-describe-agents/6-module-assessment.yml
@@ -49,9 +49,9 @@ quiz:
       - content: Dynamic Threat Detection Agent
         isCorrect: false
         explanation: "Incorrect. The Dynamic Threat Detection Agent is an always-on service that uncovers hidden threats by correlating alerts, events, and threat intelligence. It is not designed for triaging user-reported phishing emails."
-      - content: Threat Hunting Agent
+      - content: Threat Hunting Assistant
         isCorrect: false
-        explanation: "Incorrect. The Threat Hunting Agent enables investigation using natural language and KQL queries. It is not specifically designed for classifying user-reported phishing incidents."
+        explanation: "Incorrect. The Threat Hunting Assistant enables investigation using natural language and KQL queries. It is not specifically designed for classifying user-reported phishing incidents."
       - content: Security Alert Triage Agent
         isCorrect: true
         explanation: "Correct. The Security Alert Triage Agent (formerly the Phishing Triage Agent) autonomously triages and classifies alerts, including user-reported phishing emails, provides transparent rationale for its verdicts, and can incorporate analyst feedback to tune its analysis."

--- a/learn-pr/wwl-sci/security-copilot-describe-agents/includes/2-describe-agents.md
+++ b/learn-pr/wwl-sci/security-copilot-describe-agents/includes/2-describe-agents.md
@@ -60,7 +60,7 @@ Security Copilot includes agents that are seamlessly integrated with Microsoft s
 
 - **[Security Alert Triage Agent](/defender-xdr/security-alert-triage-agent)**: Helps security teams triage alerts at scale using AI-driven reasoning, identifying which alerts represent real attacks and which are false positives. This agent evolved from the Phishing Triage Agent and now supports email, identity, and cloud alerts.
 - **[Threat Intelligence Briefing Agent](/defender-xdr/threat-intel-briefing-agent-defender)**: Also available in the Defender portal, this agent gathers and synthesizes threat intelligence data to deliver concise and actionable insights to security operations teams.
-- **[Threat Hunting Agent](/defender-xdr/advanced-hunting-security-copilot-threat-hunting-agent)**: Enables threat hunting using natural language, generates KQL queries, interprets results, and guides analysts through full hunting sessions.
+- **[Threat Hunting Assistant](/defender-xdr/advanced-hunting-security-copilot-threat-hunting-assistant)**: Enables threat hunting using natural language, generates KQL queries, interprets results, and guides analysts through full hunting sessions.
 - **[Dynamic Threat Detection Agent](/defender-xdr/dynamic-threat-detection-agent)**: An always-on adaptive service that uncovers hidden threats across Defender and Microsoft Sentinel environments by correlating alerts, events, and threat intelligence.
 - **[Security Analyst Agent](/copilot/security/security-analyst-agent)**: Accessible in the Advanced hunting experience in the Defender portal, this agent helps security analysts quickly identify, assess, and prioritize risks by analyzing data from Microsoft Defender XDR, Microsoft Sentinel Log Analytics, or Microsoft Sentinel Data Lake.
 

--- a/learn-pr/wwl-sci/security-copilot-describe-agents/includes/5-describe-phishing-triage-agent.md
+++ b/learn-pr/wwl-sci/security-copilot-describe-agents/includes/5-describe-phishing-triage-agent.md
@@ -43,9 +43,9 @@ The [Threat Intelligence Briefing Agent](/defender-xdr/threat-intel-briefing-age
 | **Role-based access** | Security Administrator role is required to set up and manage the agent. Users with the same permissions as the agent can view the agent's activity and results. |
 | **Trigger** | Runs at the time interval configured during setup, or manually. |
 
-#### Threat Hunting Agent
+#### Threat Hunting Assistant
 
-The [Threat Hunting Agent](/defender-xdr/advanced-hunting-security-copilot-threat-hunting-agent) is an AI-powered conversational threat hunting agent that transforms complex data into actionable insights. Unlike traditional hunting methods that rely heavily on Kusto Query Language (KQL) expertise, the Threat Hunting Agent enables you to investigate threats using natural language from start to finish. It not only generates KQL queries but also interprets results, surfaces insights, and guides you through full hunting sessions.
+The [Threat Hunting Assistant](/defender-xdr/advanced-hunting-security-copilot-threat-hunting-assistant) is an AI-powered conversational Threat Hunting Assistant that transforms complex data into actionable insights. Unlike traditional hunting methods that rely heavily on Kusto Query Language (KQL) expertise, the Threat Hunting Assistant enables you to investigate threats using natural language from start to finish. It not only generates KQL queries but also interprets results, surfaces insights, and guides you through full hunting sessions.
 
 Key capabilities include:
 


### PR DESCRIPTION
## Summary
- Rename Threat Hunting Agent to Threat Hunting Assistant for GA
- Update related links/slug references
- Remove preview labeling for this feature where present

## GA coordination
Draft PR for review only. Do not merge or publish before Aug 5 GA approval.

## Validation
- Text-only documentation updates