### PR TITLE
Fix typo in execution context boundaries documentation

### DIFF
--- a/learn-pr/github/agent-tooling-mcp-execution-environments/includes/4-execution-context-boundaries.md
+++ b/learn-pr/github/agent-tooling-mcp-execution-environments/includes/4-execution-context-boundaries.md
@@ -86,7 +86,7 @@ Agents don't work directly on the main branch.
 
 Instead, they:
 
-- Create a new branch from the branch ypu selected
+- Create a new branch from the branch you selected
 - Make changes within that branch
 - Open a pull request targeting a base branch
 


### PR DESCRIPTION
typo on "Create a new branch from the branch ypu selected" text

Before requesting or performing a merge in upstream:

- [x] Verify that your pull request is following our PR quality criteria (items that apply to All and Learn):
       https://learn.microsoft.com/help/contribute/contribute-how-to-write-pull-request-quality-criteria?branch=main
- [x] Verify your PR has a useful title that reflects what it is for.
