### PR TITLE
Correct salary column size estimation in table design

### DIFF
--- a/learn-pr/wwl-data-ai/design-implement-database-objects/includes/3-design-implement-tables.md
+++ b/learn-pr/wwl-data-ai/design-implement-database-objects/includes/3-design-implement-tables.md
@@ -64,7 +64,7 @@ CREATE TABLE Employee (
     FirstName NVARCHAR(50),      -- ~2-100 bytes (avg 40)
     LastName NVARCHAR(50),       -- ~2-100 bytes (avg 40)
     HireDate DATE,               -- 3 bytes
-    Salary DECIMAL(10,2)         -- 5 bytes
+    Salary DECIMAL(10,2)         -- 9 bytes
 );  
 -- Estimated row size: 4 + 40 + 40 + 3 + 5 = ~92 bytes
 -- Plus row overhead (~7 bytes) = ~99 bytes per row


### PR DESCRIPTION
corrected the estimated storage size for the Salary column in the Employee table per this documentation https://learn.microsoft.com/en-us/sql/t-sql/data-types/decimal-and-numeric-transact-sql?view=sql-server-ver17

it is 9 storage bytes for precision 10-19 not 5

Before requesting or performing a merge in upstream:

- [x] Verify that your pull request is following our PR quality criteria (items that apply to All and Learn):
       https://learn.microsoft.com/help/contribute/contribute-how-to-write-pull-request-quality-criteria?branch=main
- [x] Verify your PR has a useful title that reflects what it is for.
